### PR TITLE
Update INSTALLED_APPS definition

### DIFF
--- a/fr/django_models/README.md
+++ b/fr/django_models/README.md
@@ -110,7 +110,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'blog.apps.BlogConfig',
+    'blog',
 ]
 ```
 


### PR DESCRIPTION
The current statement `blog.apps.BlogConfig` is outdated : we only need `blog`

Changes in this pull request:

-
-
-
